### PR TITLE
Fix output of MICE loggedEvents

### DIFF
--- a/UnMetImp.r
+++ b/UnMetImp.r
@@ -354,8 +354,9 @@ UnMetImp <- function(DataFrame , imp_type = 'mice' , number_m = 5 , group1 , gro
         
         #convert allmids to a "mids" object, the object format required by the mice package to run the analysis
         allmids <- as.mids(allmids)
+        allmids$loggedEvents <- micelog
 
-        return(list(mids = allmids , Msummary = msummary , QS = QualSummary , micelog = micelog))
+        return(list(mids = allmids , Msummary = msummary , QS = QualSummary))
         }
 
 }

--- a/UnMetImp.r
+++ b/UnMetImp.r
@@ -314,17 +314,7 @@ UnMetImp <- function(DataFrame , imp_type = 'mice' , number_m = 5 , group1 , gro
                                   maxN_input = maxN_input)
             allmids <- as.data.frame(do.call(cbind , lapply(allmice, '[[', "imputedcol")))
             micelog <- do.call(rbind , lapply(allmice, '[[', "micelog"))
-            # allmids <- as.data.frame(do.call(cbind , lapply(icm_names[2:length(icm_names)] , FUN = usemice2 ,
-            #                                 dataframe = DataFrame ,
-            #                                 data_cor = data_cor,
-            #                                 ccm = ccm ,
-            #                                 O=outcome,
-            #                                 co_vars = covars,
-            #                                 long = TRUE ,
-            #                                 use_co_vars = use_covars,
-            #                                 m=number_m,
-            #                                 logScale = logScale,
-            #                                 maxN_input = maxN_input)))
+
             if (logScale) {
             allmids <- cbind(firstmids , exp(as.data.frame(do.call(cbind,lapply(colnames(allmids),
                                                                                 FUN =  unscale, d = allmids)))) )

--- a/UnMetImp.r
+++ b/UnMetImp.r
@@ -322,7 +322,10 @@ UnMetImp <- function(DataFrame , imp_type = 'mice' , number_m = 5 , group1 , gro
             micelog <- rbind(firstmicelog , micelog)
         }    
         #only used if there is one variable with missing values
-        else{allmids <- firstmids}
+        else{
+          allmids <- firstmids
+          micelog <- firstmicelog
+        }
 
         #output is un-scaled and exponentialized and returned as object
         if (logScale) {

--- a/UnMetImp.r
+++ b/UnMetImp.r
@@ -137,13 +137,19 @@ usemice2 <- function(X , dataframe , data_cor, O, co_vars, ccm, long , m , use_c
     #Long is set to FALSE if this the first variable in the loop, in this case only we select the .imp (imputation number), .id (the original row number), the outcome, the covars (only if use_co_vars is TRUE), X1.
     #For the remaining iterations in the loop we do not need these columns again so we only extract Xn
 
-    if (long) {output <- complete(IMP ,  action = 'long' , include = TRUE)[X]}
+    if (long) {imputedcol <- complete(IMP ,  action = 'long' , include = TRUE)[X]}
     
-    else {output <- complete(IMP ,  action = 'long' , include = TRUE)[c('.imp','.id', O , co_vars , X )]
+    else {imputedcol <- complete(IMP ,  action = 'long' , include = TRUE)[c('.imp','.id', O , co_vars , X )]
          if (logScale) { 
-             output[X] <- exp(as.data.frame(do.call(cbind , lapply(X , FUN =  unscale, d = output)))) }
+           imputedcol[X] <- exp(as.data.frame(do.call(cbind , lapply(X , FUN =  unscale, d = imputedcol)))) }
 
-         }
+    }
+    if(is.null(IMP$loggedEvents)) {
+      micelog <- data.frame()
+    } else {
+      micelog <- data.frame(colname = X, IMP$loggedEvents)
+    }
+    output <- list(imputedcol = imputedcol , micelog = micelog)
     return(output)
 }
 
@@ -278,7 +284,7 @@ UnMetImp <- function(DataFrame , imp_type = 'mice' , number_m = 5 , group1 , gro
         }
                 
         #Only the first variable with missing values is imputed here (see usemice2 fucntion for details)
-        firstmids <- usemice2(X = icm_names[1] , dataframe = DataFrame ,
+        firstmice <- usemice2(X = icm_names[1] , dataframe = DataFrame ,
                               data_cor = data_cor,
                               ccm = ccm ,
                               O= outcome,
@@ -289,25 +295,41 @@ UnMetImp <- function(DataFrame , imp_type = 'mice' , number_m = 5 , group1 , gro
                               logScale = logScale,
                               maxN_input = maxN_input
                              )
+        firstmids <- firstmice$imputedcol
+        firstmicelog <- firstmice$micelog
 
         #if , for whatever reason, there is only one metabolite with missingness, the next step will not be run
         #Otherwise the remaining variables will be imputed then merged with the togther and with the first variable
         if (length(icm_names) > 1) {
-            allmids <- as.data.frame(do.call(cbind , lapply(icm_names[2:length(icm_names)] , FUN = usemice2 ,
-                                            dataframe = DataFrame ,
-                                            data_cor = data_cor,
-                                            ccm = ccm ,
-                                            O=outcome,
-                                            co_vars = covars,
-                                            long = TRUE ,
-                                            use_co_vars = use_covars,
-                                            m=number_m,
-                                            logScale = logScale,
-                                            maxN_input = maxN_input)))
+            allmice <- lapply(icm_names[2:length(icm_names)] , FUN = usemice2 ,
+                                  dataframe = DataFrame ,
+                                  data_cor = data_cor,
+                                  ccm = ccm ,
+                                  O=outcome,
+                                  co_vars = covars,
+                                  long = TRUE ,
+                                  use_co_vars = use_covars,
+                                  m=number_m,
+                                  logScale = logScale,
+                                  maxN_input = maxN_input)
+            allmids <- as.data.frame(do.call(cbind , lapply(allmice, '[[', "imputedcol")))
+            micelog <- do.call(rbind , lapply(allmice, '[[', "micelog"))
+            # allmids <- as.data.frame(do.call(cbind , lapply(icm_names[2:length(icm_names)] , FUN = usemice2 ,
+            #                                 dataframe = DataFrame ,
+            #                                 data_cor = data_cor,
+            #                                 ccm = ccm ,
+            #                                 O=outcome,
+            #                                 co_vars = covars,
+            #                                 long = TRUE ,
+            #                                 use_co_vars = use_covars,
+            #                                 m=number_m,
+            #                                 logScale = logScale,
+            #                                 maxN_input = maxN_input)))
             if (logScale) {
             allmids <- cbind(firstmids , exp(as.data.frame(do.call(cbind,lapply(colnames(allmids),
                                                                                 FUN =  unscale, d = allmids)))) )
-                } else {allmids <- cbind(firstmids , allmids) }
+            } else {allmids <- cbind(firstmids , allmids) }
+            micelog <- rbind(firstmicelog , micelog)
         }    
         #only used if there is one variable with missing values
         else{allmids <- firstmids}
@@ -343,7 +365,7 @@ UnMetImp <- function(DataFrame , imp_type = 'mice' , number_m = 5 , group1 , gro
         #convert allmids to a "mids" object, the object format required by the mice package to run the analysis
         allmids <- as.mids(allmids)
 
-        return(list(mids = allmids , Msummary = msummary , QS = QualSummary , micelog = allmids$loggedEvents))
+        return(list(mids = allmids , Msummary = msummary , QS = QualSummary , micelog = micelog))
         }
 
 }


### PR DESCRIPTION
Resolves #2. To get past the issue of `complete(IMP ,  action = 'long' , include = TRUE)` not saving the loggedEvents, I save the loggedEvents as a separate object and output from `usemice2()` together with the imputed data. I removed `$micelog` from the output of `UnMetImp()` and instead saved the loggedEvents in the mids object.